### PR TITLE
Fix pose tracking demo executor

### DIFF
--- a/moveit_ros/moveit_servo/CMakeLists.txt
+++ b/moveit_ros/moveit_servo/CMakeLists.txt
@@ -76,16 +76,16 @@ target_link_libraries(${CPP_DEMO_NAME} ${SERVO_LIB_NAME})
 ## Library for servoing toward a pose ##
 ########################################
 
-# TODO(henningkayser): Port pose tracking and demos in cpp_interface_example to ROS 2
-# add_library(${POSE_TRACKING} SHARED src/pose_tracking_demo.cpp)
-# ament_target_dependencies(${POSE_TRACKING} ${THIS_PACKAGE_INCLUDE_DEPENDS})
-# add_dependencies(${POSE_TRACKING} ${catkin_EXPORTED_TARGETS})
-# target_link_libraries(${POSE_TRACKING} ${SERVO_LIB_NAME})
-#
+set(POSE_TRACKING pose_tracking)
+add_library(${POSE_TRACKING} SHARED src/pose_tracking.cpp)
+ament_target_dependencies(${POSE_TRACKING} ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(${POSE_TRACKING} ${SERVO_LIB_NAME})
+
 # An example of pose tracking
-# set(POSE_TRACKING_DEMO_NAME servo_pose_tracking_demo)
-# add_executable(${POSE_TRACKING_DEMO_NAME} src/cpp_interface_example/pose_tracking_demo.cpp)
-# ament_target_dependencies(${POSE_TRACKING_DEMO_NAME} ${THIS_PACKAGE_INCLUDE_DEPENDS})
+set(POSE_TRACKING_DEMO_NAME servo_pose_tracking_demo)
+add_executable(${POSE_TRACKING_DEMO_NAME} src/cpp_interface_demo/pose_tracking_demo.cpp)
+target_link_libraries(${POSE_TRACKING_DEMO_NAME} ${POSE_TRACKING})
+ament_target_dependencies(${POSE_TRACKING_DEMO_NAME} ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 # Add executable for using a controller
 set(SERVO_CONTROLLER_INPUT servo_controller_input)
@@ -110,6 +110,8 @@ install(
     ${SERVO_CONTROLLER_INPUT}
     ${CPP_DEMO_NAME}
     ${FAKE_SERVO_CMDS_NAME}
+    ${POSE_TRACKING}
+    ${POSE_TRACKING_DEMO_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -190,15 +192,13 @@ if(BUILD_TESTING)
   #   ${catkin_LIBRARIES}
   # )
 
-  # # pose_tracking
-  # add_rostest_gtest(pose_tracking_test
-  #   test/pose_tracking_test.test
-  #   test/pose_tracking_test.cpp
-  # )
-  # target_link_libraries(pose_tracking_test
-  #   pose_tracking
-  #   ${catkin_LIBRARIES}
-  # )
+  # pose_tracking
+  ament_add_gtest_executable(test_servo_pose_tracking
+        test/pose_tracking_test.cpp
+  )
+  ament_target_dependencies(test_servo_pose_tracking ${THIS_PACKAGE_INCLUDE_DEPENDS})
+  target_link_libraries(test_servo_pose_tracking ${POSE_TRACKING})
+  add_ros_test(test/launch/test_servo_pose_tracking.test.py ARGS "test_binary_dir:=${CMAKE_CURRENT_BINARY_DIR}")
 
 endif()
 

--- a/moveit_ros/moveit_servo/config/demo_rviz_pose_tracking.rviz
+++ b/moveit_ros/moveit_servo/config/demo_rviz_pose_tracking.rviz
@@ -1,0 +1,261 @@
+Panels:
+  - Class: rviz_common/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+      Splitter Ratio: 0.5
+    Tree Height: 628
+  - Class: rviz_common/Selection
+    Name: Selection
+  - Class: rviz_common/Tool Properties
+    Expanded:
+      - /2D Goal Pose1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz_common/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz_default_plugins/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Class: moveit_rviz_plugin/PlanningScene
+      Enabled: true
+      Move Group Namespace: ""
+      Name: PlanningScene
+      Planning Scene Topic: /monitored_planning_scene
+      Robot Description: robot_description
+      Scene Geometry:
+        Scene Alpha: 0.8999999761581421
+        Scene Color: 50; 230; 50
+        Scene Display Time: 0.20000000298023224
+        Show Scene Geometry: true
+        Voxel Coloring: Z-Axis
+        Voxel Rendering: Occupied Voxels
+      Scene Robot:
+        Attached Body Color: 150; 50; 150
+        Links:
+          All Links Enabled: true
+          Expand Joint Details: false
+          Expand Link Details: false
+          Expand Tree: false
+          Link Tree Style: Links in Alphabetic Order
+          panda_hand:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          panda_leftfinger:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          panda_link0:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          panda_link1:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          panda_link2:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          panda_link3:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          panda_link4:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          panda_link5:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          panda_link6:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          panda_link7:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+          panda_link8:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+          panda_rightfinger:
+            Alpha: 1
+            Show Axes: false
+            Show Trail: false
+            Value: true
+        Robot Alpha: 1
+        Show Robot Collision: false
+        Show Robot Visual: true
+      Value: true
+    - Class: rviz_default_plugins/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: false
+        panda_hand:
+          Value: true
+        panda_leftfinger:
+          Value: false
+        panda_link0:
+          Value: false
+        panda_link1:
+          Value: false
+        panda_link2:
+          Value: false
+        panda_link3:
+          Value: false
+        panda_link4:
+          Value: false
+        panda_link5:
+          Value: false
+        panda_link6:
+          Value: false
+        panda_link7:
+          Value: false
+        panda_link8:
+          Value: false
+        panda_rightfinger:
+          Value: false
+        world:
+          Value: true
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: false
+      Tree:
+        world:
+          panda_link0:
+            panda_link1:
+              panda_link2:
+                panda_link3:
+                  panda_link4:
+                    panda_link5:
+                      panda_link6:
+                        panda_link7:
+                          panda_link8:
+                            panda_hand:
+                              panda_leftfinger:
+                                {}
+                              panda_rightfinger:
+                                {}
+      Update Interval: 0
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: world
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz_default_plugins/Interact
+      Hide Inactive Objects: true
+    - Class: rviz_default_plugins/MoveCamera
+    - Class: rviz_default_plugins/Select
+    - Class: rviz_default_plugins/FocusCamera
+    - Class: rviz_default_plugins/Measure
+      Line color: 128; 128; 0
+    - Class: rviz_default_plugins/SetInitialPose
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /initialpose
+    - Class: rviz_default_plugins/SetGoal
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /goal_pose
+    - Class: rviz_default_plugins/PublishPoint
+      Single click: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /clicked_point
+  Transformation:
+    Current:
+      Class: rviz_default_plugins/TF
+  Value: true
+  Views:
+    Current:
+      Class: rviz_default_plugins/Orbit
+      Distance: 2.155569553375244
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: -0.08608254045248032
+        Y: -0.20677587389945984
+        Z: 0.3424459993839264
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.4603978991508484
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 0.8753982782363892
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 857
+  Hide Left Dock: false
+  Hide Right Dock: true
+  QMainWindow State: 000000ff00000000fd000000040000000000000216000002fffc020000000afb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d000002ff000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb000000280020002d0020005400720061006a006500630074006f0072007900200053006c00690064006500720000000000ffffffff0000000000000000fb0000003c005400720061006a006500630074006f007200790020002d0020005400720061006a006500630074006f0072007900200053006c00690064006500720000000000ffffffff0000000000000000000000010000010f000002d2fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003d000002d2000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004420000003efc0100000002fb0000000800540069006d00650100000000000004420000000000000000fb0000000800540069006d0065010000000000000450000000000000000000000416000002ff00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: true
+  Width: 1586
+  X: 1179
+  Y: 393

--- a/moveit_ros/moveit_servo/config/panda_simulated_config_pose_tracking.yaml
+++ b/moveit_ros/moveit_servo/config/panda_simulated_config_pose_tracking.yaml
@@ -1,0 +1,68 @@
+###############################################
+# Modify all parameters related to servoing here
+###############################################
+use_gazebo: true # Whether the robot is started in a Gazebo simulation environment
+
+## Properties of incoming commands
+command_in_type: "speed_units" # "unitless"> in the range [-1:1], as if from joystick. "speed_units"> cmds are in m/s and rad/s
+scale:
+  # Scale parameters are only used if command_in_type=="unitless"
+  linear:  0.6  # Max linear velocity. Meters per publish_period. Unit is [m/s]. Only used for Cartesian commands.
+  rotational:  0.3 # Max angular velocity. Rads per publish_period. Unit is [rad/s]. Only used for Cartesian commands.
+  # Max joint angular/linear velocity. Rads or Meters per publish period. Only used for joint commands on joint_command_in_topic.
+  joint: 0.01
+
+## Properties of outgoing commands
+publish_period: 0.034  # 1/Nominal publish rate [seconds]
+
+# What type of topic does your robot driver expect?
+# Currently supported are std_msgs/Float64MultiArray or trajectory_msgs/JointTrajectory
+command_out_type: trajectory_msgs/JointTrajectory
+
+# What to publish? Can save some bandwidth as most robots only require positions or velocities
+publish_joint_positions: true
+publish_joint_velocities: true
+publish_joint_accelerations: false
+
+## Incoming Joint State properties
+low_pass_filter_coeff: 2  # Larger --> trust the filtered data more, trust the measurements less.
+
+## MoveIt properties
+move_group_name:  panda_arm  # Often 'manipulator' or 'arm'
+planning_frame: panda_link0  # The MoveIt planning frame. Often 'base_link' or 'world'
+
+## Other frames
+ee_frame_name: panda_hand  # The name of the end effector link, used to return the EE pose
+robot_link_command_frame:  panda_hand  # commands must be given in the frame of a robot link. Usually either the base or end effector
+
+## Stopping behaviour
+incoming_command_timeout:  0.1  # Stop servoing if X seconds elapse without a new command
+# If 0, republish commands forever even if the robot is stationary. Otherwise, specify num. to publish.
+# Important because ROS may drop some messages and we need the robot to halt reliably.
+num_outgoing_halt_msgs_to_publish: 4
+
+## Configure handling of singularities and joint limits
+lower_singularity_threshold:  17  # Start decelerating when the condition number hits this (close to singularity)
+hard_stop_singularity_threshold: 30 # Stop when the condition number hits this
+joint_limit_margin: 0.1 # added as a buffer to joint limits [radians]. If moving quickly, make this larger.
+
+## Topic names
+cartesian_command_in_topic: ~/delta_twist_cmds  # Topic for incoming Cartesian twist commands
+joint_command_in_topic: ~/delta_joint_cmds # Topic for incoming joint angle commands
+joint_topic: /joint_states
+status_topic: ~/status # Publish status to this topic
+command_out_topic: /fake_joint_trajectory_controller/joint_trajectory # Publish outgoing commands here
+
+## Collision checking for the entire robot body
+check_collisions: true # Check collisions?
+collision_check_rate: 10 # [Hz] Collision-checking can easily bog down a CPU if done too often.
+# Two collision check algorithms are available:
+# "threshold_distance" begins slowing down when nearer than a specified distance. Good if you want to tune collision thresholds manually.
+# "stop_distance" stops if a collision is nearer than the worst-case stopping distance and the distance is decreasing. Requires joint acceleration limits
+collision_check_type: threshold_distance
+# Parameters for "threshold_distance"-type collision checking
+self_collision_proximity_threshold: 0.01 # Start decelerating when a self-collision is this far [m]
+scene_collision_proximity_threshold: 0.02 # Start decelerating when a scene collision is this far [m]
+# Parameters for "stop_distance"-type collision checking
+collision_distance_safety_factor: 1000 # Must be >= 1. A large safety factor is recommended to account for latency
+min_allowable_collision_distance: 0.01 # Stop if a collision is closer than this [m]

--- a/moveit_ros/moveit_servo/include/moveit_servo/make_shared_from_pool.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/make_shared_from_pool.h
@@ -38,7 +38,7 @@
 
 #pragma once
 
-#include <boost/make_shared.hpp>
+#include <memory>
 #include <boost/pool/pool_alloc.hpp>
 
 namespace moveit
@@ -47,10 +47,10 @@ namespace util
 {
 // Useful template for creating messages from a message pool
 template <typename T>
-boost::shared_ptr<T> make_shared_from_pool()
+std::shared_ptr<T> make_shared_from_pool()
 {
-  using allocator_t = boost::fast_pool_allocator<boost::shared_ptr<T>>;
-  return boost::allocate_shared<T, allocator_t>(allocator_t());
+  using allocator_t = boost::fast_pool_allocator<std::shared_ptr<T>>;
+  return std::allocate_shared<T, allocator_t>(allocator_t());
 }
 
 }  // namespace util

--- a/moveit_ros/moveit_servo/launch/pose_tracking_example.launch.py
+++ b/moveit_ros/moveit_servo/launch/pose_tracking_example.launch.py
@@ -1,0 +1,88 @@
+import os
+import yaml
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from ament_index_python.packages import get_package_share_directory
+
+def load_file(package_name, file_path):
+    package_path = get_package_share_directory(package_name)
+    absolute_file_path = os.path.join(package_path, file_path)
+
+    try:
+        with open(absolute_file_path, 'r') as file:
+            return file.read()
+    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+        return None
+
+def load_yaml(package_name, file_path):
+    package_path = get_package_share_directory(package_name)
+    absolute_file_path = os.path.join(package_path, file_path)
+
+    try:
+        with open(absolute_file_path, 'r') as file:
+            return yaml.safe_load(file)
+    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+        return None
+
+
+def generate_launch_description():
+    # Get URDF and SRDF
+    robot_description_config = load_file('moveit_resources_panda_description', 'urdf/panda.urdf')
+    robot_description = {'robot_description' : robot_description_config}
+
+    robot_description_semantic_config = load_file('moveit_resources_panda_moveit_config', 'config/panda.srdf')
+    robot_description_semantic = {'robot_description_semantic' : robot_description_semantic_config}
+
+    # Get parameters for the Pose Tracking node
+    pose_tracking_yaml = load_yaml('moveit_servo', 'config/pose_tracking_settings.yaml')
+    pose_tracking_params = { 'moveit_servo' : pose_tracking_yaml }
+
+    # Get parameters for the Servo node
+    servo_yaml = load_yaml('moveit_servo', 'config/panda_simulated_config_pose_tracking.yaml')
+    servo_params = { 'moveit_servo' : servo_yaml }
+
+    kinematics_yaml = load_yaml('moveit_resources_panda_moveit_config', 'config/kinematics.yaml')
+    
+    #RViz
+    rviz_config_file = get_package_share_directory('moveit_servo') + "/config/demo_rviz_pose_tracking.rviz"
+    rviz_node = Node(package='rviz2',
+                     executable='rviz2',
+                     name='rviz2',
+                     #prefix=['xterm -e gdb -ex run --args'],
+                     output='log',
+                     arguments=['-d', rviz_config_file],
+                     parameters=[robot_description, robot_description_semantic, kinematics_yaml])
+
+    # Publishes tf's for the robot
+    robot_state_publisher = Node(
+        package='robot_state_publisher',
+        executable='robot_state_publisher',
+        output='screen',
+        parameters=[robot_description]
+    )
+
+    # A node to publish world -> panda_link0 transform
+    static_tf = Node(package='tf2_ros',
+                     executable='static_transform_publisher',
+                     name='static_transform_publisher',
+                     output='log',
+                     arguments=['0.0', '0.0', '0.0', '0.0', '0.0', '0.0', 'world', 'panda_link0'])
+
+    pose_tracking_node = Node(
+        package='moveit_servo',
+        executable='servo_pose_tracking_demo',
+        #prefix=['xterm -e gdb -ex run --args'],
+        output='screen',
+        parameters=[robot_description, robot_description_semantic, kinematics_yaml, pose_tracking_params, servo_params]
+    )
+
+    # Fake joint driver
+    fake_joint_driver_node = Node(package='fake_joint_driver',
+                                  executable='fake_joint_driver_node',
+                                  parameters=[{'controller_name': 'fake_joint_trajectory_controller'},
+                                              os.path.join(get_package_share_directory("moveit_servo"), "config", "panda_controllers.yaml"),
+                                              os.path.join(get_package_share_directory("moveit_servo"), "config", "start_positions.yaml"),
+                                              robot_description])
+
+    return LaunchDescription([rviz_node, static_tf, pose_tracking_node, fake_joint_driver_node, robot_state_publisher])
+

--- a/moveit_ros/moveit_servo/package.xml
+++ b/moveit_ros/moveit_servo/package.xml
@@ -39,6 +39,7 @@
 
   <test_depend>moveit_resources_panda_moveit_config</test_depend>
   <test_depend>ros_testing</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/moveit_ros/moveit_servo/src/cpp_interface_demo/pose_tracking_demo.cpp
+++ b/moveit_ros/moveit_servo/src/cpp_interface_demo/pose_tracking_demo.cpp
@@ -87,7 +87,7 @@ int main(int argc, char** argv)
 
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(node);
-  std::thread([&executor]() { executor.spin(); }).detach();
+  std::thread executor_thread([&executor]() { executor.spin(); });
 
   moveit_servo::ServoParametersPtr servo_parameters;
   servo_parameters = std::make_shared<moveit_servo::ServoParameters>();
@@ -179,6 +179,10 @@ int main(int argc, char** argv)
   // Make sure the tracker is stopped and clean up
   tracker.stopMotion();
   move_to_pose_thread.join();
+
+  // Kill executor thread before shutdown
+  executor.cancel();
+  executor_thread.join();
 
   rclcpp::shutdown();
   return EXIT_SUCCESS;

--- a/moveit_ros/moveit_servo/src/cpp_interface_demo/pose_tracking_demo.cpp
+++ b/moveit_ros/moveit_servo/src/cpp_interface_demo/pose_tracking_demo.cpp
@@ -173,7 +173,7 @@ int main(int argc, char** argv)
     loop_rate.sleep();
   }
 
-  rclcpp::sleep_for(std::chrono::seconds(10));
+  rclcpp::sleep_for(std::chrono::seconds(5));
   RCLCPP_DEBUG_STREAM(LOGGER, "Timer expired and unfinished motion will be terminated");
 
   // Make sure the tracker is stopped and clean up

--- a/moveit_ros/moveit_servo/src/cpp_interface_demo/pose_tracking_demo.cpp
+++ b/moveit_ros/moveit_servo/src/cpp_interface_demo/pose_tracking_demo.cpp
@@ -116,7 +116,11 @@ int main(int argc, char** argv)
   planning_scene_monitor->startPublishingPlanningScene(planning_scene_monitor::PlanningSceneMonitor::UPDATE_SCENE);
 
   // Wait for Planning Scene Monitor to setup
-  rclcpp::sleep_for(std::chrono::seconds(5));
+  if (!planning_scene_monitor->waitForCurrentRobotState(node->now(), 5.0 /* seconds */))
+  {
+    RCLCPP_ERROR_STREAM(LOGGER, "Error waiting for current robot state in PlanningSceneMonitor.");
+    exit(EXIT_FAILURE);
+  }
 
   // Create the pose tracker
   moveit_servo::PoseTracking tracker(node, servo_parameters, planning_scene_monitor);
@@ -172,9 +176,6 @@ int main(int argc, char** argv)
 
     loop_rate.sleep();
   }
-
-  rclcpp::sleep_for(std::chrono::seconds(5));
-  RCLCPP_DEBUG_STREAM(LOGGER, "Timer expired and unfinished motion will be terminated");
 
   // Make sure the tracker is stopped and clean up
   tracker.stopMotion();

--- a/moveit_ros/moveit_servo/src/cpp_interface_demo/pose_tracking_demo.cpp
+++ b/moveit_ros/moveit_servo/src/cpp_interface_demo/pose_tracking_demo.cpp
@@ -36,39 +36,43 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************/
 
-#include <std_msgs/Int8.h>
-#include <geometry_msgs/TransformStamped.h>
+#include <std_msgs/msg/int8.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
 
 #include <moveit_servo/servo.h>
 #include <moveit_servo/pose_tracking.h>
 #include <moveit_servo/status_codes.h>
+#include <moveit_servo/servo_parameters.h>
+#include <moveit_servo/servo_parameters.cpp>
 #include <moveit_servo/make_shared_from_pool.h>
 #include <thread>
 
-static const std::string LOGNAME = "cpp_interface_example";
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_servo.pose_tracking_demo");
 
 // Class for monitoring status of moveit_servo
 class StatusMonitor
 {
 public:
-  StatusMonitor(ros::NodeHandle& nh, const std::string& topic)
+  StatusMonitor(const rclcpp::Node::SharedPtr& node, const std::string& topic)
   {
-    sub_ = nh.subscribe(topic, 1, &StatusMonitor::statusCB, this);
+    sub_ = node->create_subscription<std_msgs::msg::Int8>(
+        topic, 1, std::bind(&StatusMonitor::statusCB, this, std::placeholders::_1));
   }
 
 private:
-  void statusCB(const std_msgs::Int8ConstPtr& msg)
+  void statusCB(const std_msgs::msg::Int8::ConstSharedPtr msg)
   {
     moveit_servo::StatusCode latest_status = static_cast<moveit_servo::StatusCode>(msg->data);
     if (latest_status != status_)
     {
       status_ = latest_status;
       const auto& status_str = moveit_servo::SERVO_STATUS_CODE_MAP.at(status_);
-      ROS_INFO_STREAM_NAMED(LOGNAME, "Servo status: " << status_str);
+      RCLCPP_INFO_STREAM(LOGGER, "Servo status: " << status_str);
     }
   }
+
   moveit_servo::StatusCode status_ = moveit_servo::StatusCode::INVALID;
-  ros::Subscriber sub_;
+  rclcpp::Subscription<std_msgs::msg::Int8>::SharedPtr sub_;
 };
 
 /**
@@ -78,46 +82,60 @@ private:
  */
 int main(int argc, char** argv)
 {
-  ros::init(argc, argv, LOGNAME);
-  ros::NodeHandle nh("~");
-  ros::AsyncSpinner spinner(8);
-  spinner.start();
+  rclcpp::init(argc, argv);
+  rclcpp::Node::SharedPtr node = rclcpp::Node::make_shared("pose_tracking_demo");
 
-  // Load the planning scene monitor
-  planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor;
-  planning_scene_monitor = std::make_shared<planning_scene_monitor::PlanningSceneMonitor>("robot_description");
-  if (!planning_scene_monitor->getPlanningScene())
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+  std::thread([&executor]() { executor.spin(); }).detach();
+
+  moveit_servo::ServoParametersPtr servo_parameters;
+  servo_parameters = std::make_shared<moveit_servo::ServoParameters>();
+  if (!moveit_servo::readParameters(servo_parameters, node, LOGGER))
   {
-    ROS_ERROR_STREAM_NAMED(LOGNAME, "Error in setting up the PlanningSceneMonitor.");
+    RCLCPP_ERROR_STREAM(LOGGER, "Could not get servo parameters!");
     exit(EXIT_FAILURE);
   }
 
+  // Load the planning scene monitor
+  planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor;
+  planning_scene_monitor = std::make_shared<planning_scene_monitor::PlanningSceneMonitor>(node, "robot_description");
+  if (!planning_scene_monitor->getPlanningScene())
+  {
+    RCLCPP_ERROR_STREAM(LOGGER, "Error in setting up the PlanningSceneMonitor.");
+    exit(EXIT_FAILURE);
+  }
+
+  planning_scene_monitor->providePlanningSceneService();
   planning_scene_monitor->startSceneMonitor();
   planning_scene_monitor->startWorldGeometryMonitor(
       planning_scene_monitor::PlanningSceneMonitor::DEFAULT_COLLISION_OBJECT_TOPIC,
       planning_scene_monitor::PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_WORLD_TOPIC,
       false /* skip octomap monitor */);
-  planning_scene_monitor->startStateMonitor();
+  planning_scene_monitor->startStateMonitor(servo_parameters->joint_topic);
+  planning_scene_monitor->startPublishingPlanningScene(planning_scene_monitor::PlanningSceneMonitor::UPDATE_SCENE);
+
+  // Wait for Planning Scene Monitor to setup
+  rclcpp::sleep_for(std::chrono::seconds(5));
 
   // Create the pose tracker
-  moveit_servo::PoseTracking tracker(nh, planning_scene_monitor);
+  moveit_servo::PoseTracking tracker(node, servo_parameters, planning_scene_monitor);
 
   // Make a publisher for sending pose commands
-  ros::Publisher target_pose_pub =
-      nh.advertise<geometry_msgs::PoseStamped>("target_pose", 1 /* queue */, true /* latch */);
+  auto target_pose_pub = node->create_publisher<geometry_msgs::msg::PoseStamped>("target_pose", 1 /* queue */);
 
   // Subscribe to servo status (and log it when it changes)
-  StatusMonitor status_monitor(nh, "status");
+  StatusMonitor status_monitor(node, servo_parameters->status_topic);
 
-  Eigen::Vector3d lin_tol{ 0.01, 0.01, 0.01 };
-  double rot_tol = 0.1;
+  Eigen::Vector3d lin_tol{ 0.001, 0.001, 0.001 };
+  double rot_tol = 0.01;
 
   // Get the current EE transform
-  geometry_msgs::TransformStamped current_ee_tf;
+  geometry_msgs::msg::TransformStamped current_ee_tf;
   tracker.getCommandFrameTransform(current_ee_tf);
 
   // Convert it to a Pose
-  geometry_msgs::PoseStamped target_pose;
+  geometry_msgs::msg::PoseStamped target_pose;
   target_pose.header.frame_id = current_ee_tf.header.frame_id;
   target_pose.pose.position.x = current_ee_tf.transform.translation.x;
   target_pose.pose.position.y = current_ee_tf.transform.translation.y;
@@ -132,28 +150,36 @@ int main(int argc, char** argv)
   tracker.resetTargetPose();
 
   // Publish target pose
-  target_pose.header.stamp = ros::Time::now();
-  target_pose_pub.publish(target_pose);
+  target_pose.header.stamp = node->now();
+  target_pose_pub->publish(target_pose);
 
   // Run the pose tracking in a new thread
-  std::thread move_to_pose_thread(
-      [&tracker, &lin_tol, &rot_tol] { tracker.moveToPose(lin_tol, rot_tol, 0.1 /* target pose timeout */); });
+  std::thread move_to_pose_thread([&tracker, &lin_tol, &rot_tol] {
+    moveit_servo::PoseTrackingStatusCode tracking_status =
+        tracker.moveToPose(lin_tol, rot_tol, 0.1 /* target pose timeout */);
+    RCLCPP_INFO_STREAM(LOGGER, "Pose tracker exited with status: "
+                                   << moveit_servo::POSE_TRACKING_STATUS_CODE_MAP.at(tracking_status));
+  });
 
-  ros::Rate loop_rate(50);
+  rclcpp::Rate loop_rate(50);
   for (size_t i = 0; i < 500; ++i)
   {
     // Modify the pose target a little bit each cycle
     // This is a dynamic pose target
     target_pose.pose.position.z += 0.0004;
-    target_pose.header.stamp = ros::Time::now();
-    target_pose_pub.publish(target_pose);
+    target_pose.header.stamp = node->now();
+    target_pose_pub->publish(target_pose);
 
     loop_rate.sleep();
   }
+
+  rclcpp::sleep_for(std::chrono::seconds(10));
+  RCLCPP_DEBUG_STREAM(LOGGER, "Timer expired and unfinished motion will be terminated");
 
   // Make sure the tracker is stopped and clean up
   tracker.stopMotion();
   move_to_pose_thread.join();
 
+  rclcpp::shutdown();
   return EXIT_SUCCESS;
 }

--- a/moveit_ros/moveit_servo/src/cpp_interface_demo/servo_cpp_interface_demo.cpp
+++ b/moveit_ros/moveit_servo/src/cpp_interface_demo/servo_cpp_interface_demo.cpp
@@ -173,7 +173,7 @@ int main(int argc, char** argv)
   ps.world = psw;
 
   // Publish the collision object to the planning scene
-  auto scene_pub = node->create_publisher<moveit_msgs::msg::PlanningScene>("/planning_scene", 10);
+  auto scene_pub = node->create_publisher<moveit_msgs::msg::PlanningScene>("planning_scene", 10);
   scene_pub->publish(ps);
 
   // Start the Servo object, and start publishing commands to it

--- a/moveit_ros/moveit_servo/src/cpp_interface_example/pose_tracking_demo.cpp
+++ b/moveit_ros/moveit_servo/src/cpp_interface_example/pose_tracking_demo.cpp
@@ -36,7 +36,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************/
 
-#include <std_msgs/Int8.h>
+#include <std_msgs/msg/int8.hpp>
 #include <geometry_msgs/TransformStamped.h>
 
 #include <moveit_servo/servo.h>

--- a/moveit_ros/moveit_servo/src/pose_tracking.cpp
+++ b/moveit_ros/moveit_servo/src/pose_tracking.cpp
@@ -33,21 +33,28 @@
  *********************************************************************/
 
 #include "moveit_servo/pose_tracking.h"
+#include "moveit_servo/servo_parameters.cpp"
+
+#include <chrono>
+using namespace std::literals;
 
 namespace
 {
-constexpr char LOGNAME[] = "pose_tracking";
-constexpr double DEFAULT_LOOP_RATE = 100;  // Hz
-constexpr double ROS_STARTUP_WAIT = 10;    // sec
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_servo.pose_tracking");
+constexpr double DEFAULT_LOOP_RATE = 100;   // Hz
+constexpr double ROS_STARTUP_WAIT = 10;     // sec
+constexpr size_t LOG_THROTTLE_PERIOD = 10;  // sec
 }  // namespace
 
 namespace moveit_servo
 {
-PoseTracking::PoseTracking(const ros::NodeHandle& nh,
+PoseTracking::PoseTracking(const rclcpp::Node::SharedPtr& node, const ServoParametersPtr& servo_parameters,
                            const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor)
-  : nh_(nh)
+  : node_(node)
+  , servo_parameters_(servo_parameters)
   , planning_scene_monitor_(planning_scene_monitor)
-  , loop_rate_(DEFAULT_LOOP_RATE)
+  , loop_rate_(1.0 / servo_parameters->publish_period)
+  , transform_buffer_(node_->get_clock())
   , transform_listener_(transform_buffer_)
   , stop_requested_(false)
   , angular_error_(0)
@@ -64,16 +71,16 @@ PoseTracking::PoseTracking(const ros::NodeHandle& nh,
   initializePID(angular_pid_config_, cartesian_orientation_pids_);
 
   // Use the C++ interface that Servo provides
-  servo_ = std::make_unique<moveit_servo::Servo>(nh_, planning_scene_monitor_);
+  servo_ = std::make_unique<moveit_servo::Servo>(node_, servo_parameters_, planning_scene_monitor_);
   servo_->start();
 
   // Connect to Servo ROS interfaces
-  target_pose_sub_ =
-      nh_.subscribe<geometry_msgs::PoseStamped>("target_pose", 1, &PoseTracking::targetPoseCallback, this);
+  target_pose_sub_ = node_->create_subscription<geometry_msgs::msg::PoseStamped>(
+      "target_pose", 1, std::bind(&PoseTracking::targetPoseCallback, this, std::placeholders::_1));
 
   // Publish outgoing twist commands to the Servo object
   twist_stamped_pub_ =
-      nh_.advertise<geometry_msgs::TwistStamped>(servo_->getParameters().cartesian_command_in_topic, 1);
+      node_->create_publisher<geometry_msgs::msg::TwistStamped>(servo_->getParameters()->cartesian_command_in_topic, 1);
 }
 
 PoseTrackingStatusCode PoseTracking::moveToPose(const Eigen::Vector3d& positional_tolerance,
@@ -81,20 +88,22 @@ PoseTrackingStatusCode PoseTracking::moveToPose(const Eigen::Vector3d& positiona
 {
   // Wait a bit for a target pose message to arrive.
   // The target pose may get updated by new messages as the robot moves (in a callback function).
-  const ros::Time start_time = ros::Time::now();
+  const rclcpp::Time start_time = node_->now();
+  rclcpp::Clock clock;
+
   while ((!haveRecentTargetPose(target_pose_timeout) || !haveRecentEndEffectorPose(target_pose_timeout)) &&
-         ((ros::Time::now() - start_time).toSec() < target_pose_timeout))
+         ((node_->now() - start_time).seconds() < target_pose_timeout))
   {
     if (servo_->getCommandFrameTransform(command_frame_transform_))
     {
-      command_frame_transform_stamp_ = ros::Time::now();
+      command_frame_transform_stamp_ = node_->now();
     }
-    ros::Duration(0.001).sleep();
+    std::this_thread::sleep_for(1ms);
   }
 
   if (!haveRecentTargetPose(target_pose_timeout))
   {
-    ROS_ERROR_STREAM_NAMED(LOGNAME, "The target pose was not updated recently. Aborting.");
+    RCLCPP_ERROR_STREAM(LOGGER, "The target pose was not updated recently. Aborting.");
     return PoseTrackingStatusCode::NO_RECENT_TARGET_POSE;
   }
 
@@ -103,31 +112,41 @@ PoseTrackingStatusCode PoseTracking::moveToPose(const Eigen::Vector3d& positiona
   // - Target pose becomes outdated
   // - Command frame transform becomes outdated
   // - Another thread requested a stop
-  while (ros::ok() && !satisfiesPoseTolerance(positional_tolerance, angular_tolerance))
+  while (rclcpp::ok())
   {
+    if (satisfiesPoseTolerance(positional_tolerance, angular_tolerance))
+    {
+      RCLCPP_INFO_STREAM(LOGGER, "The target pose is achieved!");
+      break;
+    }
     // Attempt to update robot pose
     if (servo_->getCommandFrameTransform(command_frame_transform_))
     {
-      command_frame_transform_stamp_ = ros::Time::now();
+      command_frame_transform_stamp_ = node_->now();
     }
 
     // Check that end-effector pose (command frame transform) is recent enough.
     if (!haveRecentEndEffectorPose(target_pose_timeout))
     {
-      ROS_ERROR_STREAM_NAMED(LOGNAME, "The end effector pose was not updated in time. Aborting.");
+      RCLCPP_ERROR_STREAM(LOGGER, "The end effector pose was not updated in time. Aborting.");
       doPostMotionReset();
       return PoseTrackingStatusCode::NO_RECENT_END_EFFECTOR_POSE;
     }
 
     if (stop_requested_)
     {
-      ROS_INFO_STREAM_NAMED(LOGNAME, "Halting servo motion, a stop was requested.");
+      RCLCPP_INFO_STREAM(LOGGER, "Halting servo motion, a stop was requested.");
       doPostMotionReset();
       return PoseTrackingStatusCode::STOP_REQUESTED;
     }
 
     // Compute servo command from PID controller output and send it to the Servo object, for execution
-    twist_stamped_pub_.publish(calculateTwistCommand());
+    twist_stamped_pub_->publish(*calculateTwistCommand());
+
+    if (!loop_rate_.sleep())
+    {
+      RCLCPP_WARN_STREAM_THROTTLE(LOGGER, clock, LOG_THROTTLE_PERIOD, "Target control rate was missed");
+    }
   }
 
   doPostMotionReset();
@@ -136,36 +155,18 @@ PoseTrackingStatusCode PoseTracking::moveToPose(const Eigen::Vector3d& positiona
 
 void PoseTracking::readROSParams()
 {
-  // Optional parameter sub-namespace specified in the launch file. All other parameters will be read from this namespace.
-  std::string parameter_ns;
-  ros::param::get("~parameter_ns", parameter_ns);
+  const std::string ns = "moveit_servo";
 
-  // If parameters have been loaded into sub-namespace within the node namespace, append the parameter namespace
-  // to load the parameters correctly.
-  ros::NodeHandle nh = parameter_ns.empty() ? nh_ : ros::NodeHandle(nh_, parameter_ns);
+  declareOrGetParam(planning_frame_, ns + ".planning_frame", node_, LOGGER);
+  declareOrGetParam(move_group_name_, ns + ".move_group_name", node_, LOGGER);
 
-  // Wait for ROS parameters to load
-  ros::Time begin = ros::Time::now();
-  while (ros::ok() && !nh.hasParam("planning_frame") && ((ros::Time::now() - begin).toSec() < ROS_STARTUP_WAIT))
-  {
-    ROS_WARN_STREAM_NAMED(LOGNAME, "Waiting for parameter: "
-                                       << "planning_frame");
-    ros::Duration(0.1).sleep();
-  }
-
-  std::size_t error = 0;
-
-  error += !rosparam_shortcuts::get(LOGNAME, nh, "planning_frame", planning_frame_);
-  error += !rosparam_shortcuts::get(LOGNAME, nh, "move_group_name", move_group_name_);
   if (!planning_scene_monitor_->getRobotModel()->hasJointModelGroup(move_group_name_))
   {
-    ++error;
-    ROS_ERROR_STREAM_NAMED(LOGNAME, "Unable to find the specified joint model group: " << move_group_name_);
+    RCLCPP_ERROR_STREAM(LOGGER, "Unable to find the specified joint model group: " << move_group_name_);
   }
 
   double publish_period;
-  error += !rosparam_shortcuts::get(LOGNAME, nh, "publish_period", publish_period);
-  loop_rate_ = ros::Rate(1 / publish_period);
+  declareOrGetParam(publish_period, ns + ".publish_period", node_, LOGGER);
 
   x_pid_config_.dt = publish_period;
   y_pid_config_.dt = publish_period;
@@ -173,27 +174,26 @@ void PoseTracking::readROSParams()
   angular_pid_config_.dt = publish_period;
 
   double windup_limit;
-  error += !rosparam_shortcuts::get(LOGNAME, nh, "windup_limit", windup_limit);
+  declareOrGetParam(windup_limit, ns + ".windup_limit", node_, LOGGER);
   x_pid_config_.windup_limit = windup_limit;
   y_pid_config_.windup_limit = windup_limit;
   z_pid_config_.windup_limit = windup_limit;
   angular_pid_config_.windup_limit = windup_limit;
 
-  error += !rosparam_shortcuts::get(LOGNAME, nh, "x_proportional_gain", x_pid_config_.k_p);
-  error += !rosparam_shortcuts::get(LOGNAME, nh, "y_proportional_gain", y_pid_config_.k_p);
-  error += !rosparam_shortcuts::get(LOGNAME, nh, "z_proportional_gain", z_pid_config_.k_p);
-  error += !rosparam_shortcuts::get(LOGNAME, nh, "x_integral_gain", x_pid_config_.k_i);
-  error += !rosparam_shortcuts::get(LOGNAME, nh, "y_integral_gain", y_pid_config_.k_i);
-  error += !rosparam_shortcuts::get(LOGNAME, nh, "z_integral_gain", z_pid_config_.k_i);
-  error += !rosparam_shortcuts::get(LOGNAME, nh, "x_derivative_gain", x_pid_config_.k_d);
-  error += !rosparam_shortcuts::get(LOGNAME, nh, "y_derivative_gain", y_pid_config_.k_d);
-  error += !rosparam_shortcuts::get(LOGNAME, nh, "z_derivative_gain", z_pid_config_.k_d);
+  declareOrGetParam(x_pid_config_.k_p, ns + ".x_proportional_gain", node_, LOGGER);
+  declareOrGetParam(x_pid_config_.k_p, ns + ".x_proportional_gain", node_, LOGGER);
+  declareOrGetParam(y_pid_config_.k_p, ns + ".y_proportional_gain", node_, LOGGER);
+  declareOrGetParam(z_pid_config_.k_p, ns + ".z_proportional_gain", node_, LOGGER);
+  declareOrGetParam(x_pid_config_.k_i, ns + ".x_integral_gain", node_, LOGGER);
+  declareOrGetParam(y_pid_config_.k_i, ns + ".y_integral_gain", node_, LOGGER);
+  declareOrGetParam(z_pid_config_.k_i, ns + ".z_integral_gain", node_, LOGGER);
+  declareOrGetParam(x_pid_config_.k_d, ns + ".x_derivative_gain", node_, LOGGER);
+  declareOrGetParam(y_pid_config_.k_d, ns + ".y_derivative_gain", node_, LOGGER);
+  declareOrGetParam(z_pid_config_.k_d, ns + ".z_derivative_gain", node_, LOGGER);
 
-  error += !rosparam_shortcuts::get(LOGNAME, nh, "angular_proportional_gain", angular_pid_config_.k_p);
-  error += !rosparam_shortcuts::get(LOGNAME, nh, "angular_integral_gain", angular_pid_config_.k_i);
-  error += !rosparam_shortcuts::get(LOGNAME, nh, "angular_derivative_gain", angular_pid_config_.k_d);
-
-  rosparam_shortcuts::shutdownIfError(ros::this_node::getName(), error);
+  declareOrGetParam(angular_pid_config_.k_p, ns + ".angular_proportional_gain", node_, LOGGER);
+  declareOrGetParam(angular_pid_config_.k_i, ns + ".angular_integral_gain", node_, LOGGER);
+  declareOrGetParam(angular_pid_config_.k_d, ns + ".angular_derivative_gain", node_, LOGGER);
 }
 
 void PoseTracking::initializePID(const PIDConfig& pid_config, std::vector<control_toolbox::Pid>& pid_vector)
@@ -206,12 +206,12 @@ void PoseTracking::initializePID(const PIDConfig& pid_config, std::vector<contro
 bool PoseTracking::haveRecentTargetPose(const double timespan)
 {
   std::lock_guard<std::mutex> lock(target_pose_mtx_);
-  return ((ros::Time::now() - target_pose_.header.stamp).toSec() < timespan);
+  return ((node_->now() - target_pose_.header.stamp).seconds() < timespan);
 }
 
 bool PoseTracking::haveRecentEndEffectorPose(const double timespan)
 {
-  return ((ros::Time::now() - command_frame_transform_stamp_).toSec() < timespan);
+  return ((node_->now() - command_frame_transform_stamp_).seconds() < timespan);
 }
 
 bool PoseTracking::satisfiesPoseTolerance(const Eigen::Vector3d& positional_tolerance, const double angular_tolerance)
@@ -225,35 +225,35 @@ bool PoseTracking::satisfiesPoseTolerance(const Eigen::Vector3d& positional_tole
           (std::abs(z_error) < positional_tolerance(2)) && (std::abs(angular_error_) < angular_tolerance));
 }
 
-void PoseTracking::targetPoseCallback(const geometry_msgs::PoseStampedConstPtr& msg)
+void PoseTracking::targetPoseCallback(const geometry_msgs::msg::PoseStamped::ConstSharedPtr msg)
 {
   std::lock_guard<std::mutex> lock(target_pose_mtx_);
   target_pose_ = *msg;
-
   // If the target pose is not defined in planning frame, transform the target pose.
   if (target_pose_.header.frame_id != planning_frame_)
   {
     try
     {
-      geometry_msgs::TransformStamped target_to_planning_frame = transform_buffer_.lookupTransform(
-          planning_frame_, target_pose_.header.frame_id, ros::Time(0), ros::Duration(0.1));
+      geometry_msgs::msg::TransformStamped target_to_planning_frame = transform_buffer_.lookupTransform(
+          planning_frame_, target_pose_.header.frame_id, rclcpp::Time(0), rclcpp::Duration(0.1));
       tf2::doTransform(target_pose_, target_pose_, target_to_planning_frame);
+      target_pose_.header.stamp = node_->now();
     }
     catch (const tf2::TransformException& ex)
     {
-      ROS_WARN_STREAM_NAMED(LOGNAME, ex.what());
+      RCLCPP_WARN_STREAM(LOGGER, ex.what());
       return;
     }
   }
 }
 
-geometry_msgs::TwistStampedConstPtr PoseTracking::calculateTwistCommand()
+geometry_msgs::msg::TwistStamped::ConstSharedPtr PoseTracking::calculateTwistCommand()
 {
   // use the shared pool to create a message more efficiently
-  auto msg = moveit::util::make_shared_from_pool<geometry_msgs::TwistStamped>();
+  auto msg = moveit::util::make_shared_from_pool<geometry_msgs::msg::TwistStamped>();
 
   // Get twist components from PID controllers
-  geometry_msgs::Twist& twist = msg->twist;
+  geometry_msgs::msg::Twist& twist = msg->twist;
   Eigen::Quaterniond q_desired;
 
   // Scope mutex locking only to operations which require access to target pose.
@@ -263,11 +263,11 @@ geometry_msgs::TwistStampedConstPtr PoseTracking::calculateTwistCommand()
 
     // Position
     twist.linear.x = cartesian_position_pids_[0].computeCommand(
-        target_pose_.pose.position.x - command_frame_transform_.translation()(0), loop_rate_.expectedCycleTime());
+        target_pose_.pose.position.x - command_frame_transform_.translation()(0), loop_rate_.period().count());
     twist.linear.y = cartesian_position_pids_[1].computeCommand(
-        target_pose_.pose.position.y - command_frame_transform_.translation()(1), loop_rate_.expectedCycleTime());
+        target_pose_.pose.position.y - command_frame_transform_.translation()(1), loop_rate_.period().count());
     twist.linear.z = cartesian_position_pids_[2].computeCommand(
-        target_pose_.pose.position.z - command_frame_transform_.translation()(2), loop_rate_.expectedCycleTime());
+        target_pose_.pose.position.z - command_frame_transform_.translation()(2), loop_rate_.period().count());
 
     // Orientation algorithm:
     // - Find the orientation error as a quaternion: q_error = q_desired * q_current ^ -1
@@ -284,13 +284,12 @@ geometry_msgs::TwistStampedConstPtr PoseTracking::calculateTwistCommand()
   Eigen::AngleAxisd axis_angle(q_error);
   // Cache the angular error, for rotation tolerance checking
   angular_error_ = axis_angle.angle();
-  double ang_vel_magnitude =
-      cartesian_orientation_pids_[0].computeCommand(angular_error_, loop_rate_.expectedCycleTime());
+  double ang_vel_magnitude = cartesian_orientation_pids_[0].computeCommand(angular_error_, loop_rate_.period().count());
   twist.angular.x = ang_vel_magnitude * axis_angle.axis()[0];
   twist.angular.y = ang_vel_magnitude * axis_angle.axis()[1];
   twist.angular.z = ang_vel_magnitude * axis_angle.axis()[2];
 
-  msg->header.stamp = ros::Time::now();
+  msg->header.stamp = node_->now();
 
   return msg;
 }
@@ -343,20 +342,20 @@ void PoseTracking::updatePIDConfig(const double x_proportional_gain, const doubl
 void PoseTracking::getPIDErrors(double& x_error, double& y_error, double& z_error, double& orientation_error)
 {
   double dummy1, dummy2;
-  cartesian_position_pids_.at(0).getCurrentPIDErrors(&x_error, &dummy1, &dummy2);
-  cartesian_position_pids_.at(1).getCurrentPIDErrors(&y_error, &dummy1, &dummy2);
-  cartesian_position_pids_.at(2).getCurrentPIDErrors(&z_error, &dummy1, &dummy2);
-  cartesian_orientation_pids_.at(0).getCurrentPIDErrors(&orientation_error, &dummy1, &dummy2);
+  cartesian_position_pids_.at(0).getCurrentPIDErrors(x_error, dummy1, dummy2);
+  cartesian_position_pids_.at(1).getCurrentPIDErrors(y_error, dummy1, dummy2);
+  cartesian_position_pids_.at(2).getCurrentPIDErrors(z_error, dummy1, dummy2);
+  cartesian_orientation_pids_.at(0).getCurrentPIDErrors(orientation_error, dummy1, dummy2);
 }
 
 void PoseTracking::resetTargetPose()
 {
   std::lock_guard<std::mutex> lock(target_pose_mtx_);
-  target_pose_ = geometry_msgs::PoseStamped();
-  target_pose_.header.stamp = ros::Time(0);
+  target_pose_ = geometry_msgs::msg::PoseStamped();
+  target_pose_.header.stamp = rclcpp::Time(RCL_ROS_TIME);
 }
 
-bool PoseTracking::getCommandFrameTransform(geometry_msgs::TransformStamped& transform)
+bool PoseTracking::getCommandFrameTransform(geometry_msgs::msg::TransformStamped& transform)
 {
   return servo_->getCommandFrameTransform(transform);
 }

--- a/moveit_ros/moveit_servo/src/pose_tracking.cpp
+++ b/moveit_ros/moveit_servo/src/pose_tracking.cpp
@@ -41,8 +41,6 @@ using namespace std::literals;
 namespace
 {
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_servo.pose_tracking");
-constexpr double DEFAULT_LOOP_RATE = 100;   // Hz
-constexpr double ROS_STARTUP_WAIT = 10;     // sec
 constexpr size_t LOG_THROTTLE_PERIOD = 10;  // sec
 }  // namespace
 
@@ -235,7 +233,7 @@ void PoseTracking::targetPoseCallback(const geometry_msgs::msg::PoseStamped::Con
     try
     {
       geometry_msgs::msg::TransformStamped target_to_planning_frame = transform_buffer_.lookupTransform(
-          planning_frame_, target_pose_.header.frame_id, rclcpp::Time(0), rclcpp::Duration(0.1));
+          planning_frame_, target_pose_.header.frame_id, rclcpp::Time(0), rclcpp::Duration(0));
       tf2::doTransform(target_pose_, target_pose_, target_to_planning_frame);
       target_pose_.header.stamp = node_->now();
     }

--- a/moveit_ros/moveit_servo/src/servo.cpp
+++ b/moveit_ros/moveit_servo/src/servo.cpp
@@ -100,7 +100,7 @@ bool Servo::getCommandFrameTransform(Eigen::Isometry3d& transform)
 
 bool Servo::getCommandFrameTransform(geometry_msgs::msg::TransformStamped& transform)
 {
-  return servo_calcs_->getEEFrameTransform(transform);
+  return servo_calcs_->getCommandFrameTransform(transform);
 }
 
 bool Servo::getEEFrameTransform(Eigen::Isometry3d& transform)

--- a/moveit_ros/moveit_servo/test/config/pose_tracking_settings.yaml
+++ b/moveit_ros/moveit_servo/test/config/pose_tracking_settings.yaml
@@ -1,0 +1,22 @@
+#################################
+# PID parameters for pose seeking
+#################################
+
+
+# Maximum value of error integral for all PID controllers
+windup_limit: 0.05
+
+# PID gains
+x_proportional_gain: 1.5
+y_proportional_gain: 1.5
+z_proportional_gain: 1.5
+x_integral_gain: 0.0
+y_integral_gain: 0.0
+z_integral_gain: 0.0
+x_derivative_gain: 0.0
+y_derivative_gain: 0.0
+z_derivative_gain: 0.0
+
+angular_proportional_gain: 0.5
+angular_integral_gain: 0.0
+angular_derivative_gain: 0.0

--- a/moveit_ros/moveit_servo/test/launch/test_servo_collision.test.py
+++ b/moveit_ros/moveit_servo/test/launch/test_servo_collision.test.py
@@ -3,18 +3,21 @@ import sys
 import unittest
 
 import launch_testing.asserts
+
 sys.path.append(os.path.dirname(__file__))
-from servo_launch_test_common import generate_servo_test_description 
+from servo_launch_test_common import generate_servo_test_description
+
 
 def generate_test_description():
     return generate_servo_test_description(gtest_name='test_servo_collision',
-                                            start_position_path='../config/collision_start_positions.yaml')
+                                           start_position_path='../config/collision_start_positions.yaml')
 
 
 class TestGTestProcessActive(unittest.TestCase):
 
     def test_gtest_run_complete(self, proc_info, servo_gtest, test_container, fake_joint_driver_node):
         proc_info.assertWaitForShutdown(servo_gtest, timeout=4000.0)
+
 
 @launch_testing.post_shutdown_test()
 class TestGTestProcessPostShutdown(unittest.TestCase):

--- a/moveit_ros/moveit_servo/test/launch/test_servo_pose_tracking.test.py
+++ b/moveit_ros/moveit_servo/test/launch/test_servo_pose_tracking.test.py
@@ -1,13 +1,21 @@
 import os
 import yaml
+import unittest
+import pytest
+
+import launch_ros
 import launch
+import launch_testing.actions
+import launch_testing.asserts
+
 from launch import LaunchDescription
 from launch.some_substitutions_type import SomeSubstitutionsType
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
-import launch_testing.actions
-from launch_ros.actions import ComposableNodeContainer, Node
-from launch_ros.descriptions import ComposableNode
+
 from ament_index_python.packages import get_package_share_directory
+
+from launch_ros.actions import Node, ComposableNodeContainer
+from launch_ros.descriptions import ComposableNode
 
 def load_file(package_name, file_path):
     package_path = get_package_share_directory(package_name)
@@ -29,13 +37,10 @@ def load_yaml(package_name, file_path):
     except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
         return None
 
+
 def generate_servo_test_description(*args,
                                     gtest_name: SomeSubstitutionsType,
                                     start_position_path: SomeSubstitutionsType = '../config/start_positions.yaml'):
-    
-    # Get parameters using the demo config file
-    servo_yaml = load_yaml('moveit_servo', 'config/panda_simulated_config.yaml')
-    servo_params = { 'moveit_servo' : servo_yaml }
 
     # Get URDF and SRDF
     robot_description_config = load_file('moveit_resources_panda_description', 'urdf/panda.urdf')
@@ -44,17 +49,28 @@ def generate_servo_test_description(*args,
     robot_description_semantic_config = load_file('moveit_resources_panda_moveit_config', 'config/panda.srdf')
     robot_description_semantic = {'robot_description_semantic' : robot_description_semantic_config}
 
-    # Is a perfect controller without dynamics
+    # Get parameters for the Pose Tracking node
+    pose_tracking_yaml = load_yaml('moveit_servo', 'config/pose_tracking_settings.yaml')
+    pose_tracking_params = { 'moveit_servo' : pose_tracking_yaml }
+
+    # Get parameters for the Servo node
+    servo_yaml = load_yaml('moveit_servo', 'config/panda_simulated_config_pose_tracking.yaml')
+    servo_params = { 'moveit_servo' : servo_yaml }
+
+    kinematics_yaml = load_yaml('moveit_resources_panda_moveit_config', 'config/kinematics.yaml')
+
+    # Fake joint driver
     fake_joint_driver_node = Node(package='fake_joint_driver',
                                   executable='fake_joint_driver_node',
                                   parameters=[{'controller_name': 'fake_joint_trajectory_controller'},
                                               os.path.join(get_package_share_directory("moveit_servo"), "config", "panda_controllers.yaml"),
-                                              os.path.join(os.path.dirname(__file__), start_position_path),
-                                              robot_description])
-
+                                              os.path.join(get_package_share_directory("moveit_servo"), "config", "start_positions.yaml"),
+                                              robot_description]
+                                )
+    
     # Component nodes for tf and Servo
     test_container = ComposableNodeContainer(
-            name='test_servo_integration_container',
+            name='test_pose_tracking_container',
             namespace='/',
             package='rclcpp_components',
             executable='component_container',
@@ -69,20 +85,14 @@ def generate_servo_test_description(*args,
                     plugin='tf2_ros::StaticTransformBroadcasterNode',
                     name='static_tf2_broadcaster',
                     parameters=[ {'/child_frame_id' : 'panda_link0', '/frame_id' : 'world'} ]),
-                ComposableNode(
-                    package='moveit_servo',
-                    plugin='moveit_servo::ServoServer',
-                    name='servo_server',
-                    parameters=[servo_params, robot_description, robot_description_semantic],
-                    extra_arguments=[{'use_intra_process_comm': True}])
             ],
             output='screen',
     )
 
-    servo_gtest = launch_testing.actions.GTest(
-        path=PathJoinSubstitution([LaunchConfiguration('test_binary_dir'), gtest_name]),
-        timeout=40.0, output='screen'
-    )
+    pose_tracking_gtest = launch_ros.actions.Node(
+                executable=PathJoinSubstitution([LaunchConfiguration('test_binary_dir'), gtest_name]),
+                parameters=[robot_description, robot_description_semantic, pose_tracking_params, servo_params, kinematics_yaml]
+        )
 
     return launch.LaunchDescription([
         launch.actions.DeclareLaunchArgument(name='test_binary_dir',
@@ -90,7 +100,23 @@ def generate_servo_test_description(*args,
                                                          'containing test executables'),
         fake_joint_driver_node,
         test_container,
-        servo_gtest,
+        pose_tracking_gtest,
         launch_testing.actions.ReadyToTest()
-    ]), {'test_container': test_container, 'servo_gtest': servo_gtest, 'fake_joint_driver_node': fake_joint_driver_node}
+    ]), {'test_container': test_container ,'servo_gtest': pose_tracking_gtest, 'fake_joint_driver_node': fake_joint_driver_node }
 
+def generate_test_description():
+    return generate_servo_test_description(gtest_name='test_servo_pose_tracking',
+                                           start_position_path='../config/collision_start_positions.yaml')
+
+
+class TestGTestProcessActive(unittest.TestCase):
+
+    def test_gtest_run_complete(self, proc_info, test_container, servo_gtest, fake_joint_driver_node):
+        proc_info.assertWaitForShutdown(servo_gtest, timeout=4000.0)
+
+
+@launch_testing.post_shutdown_test()
+class TestGTestProcessPostShutdown(unittest.TestCase):
+
+    def test_gtest_pass(self, proc_info, test_container, servo_gtest, fake_joint_driver_node):
+        launch_testing.asserts.assertExitCodes(proc_info, process=servo_gtest)


### PR DESCRIPTION
This fixes the crashing demo by canceling the async executor before calling `rclcpp::shutdown()` (see related issue https://github.com/ros2/rclcpp/issues/1139). I think the cause of the crash was that the detached thread would still spin the executor after `rclcpp::shutdown()` has killed the global context (which was also accessed by the executor only guarded by testing `rclcpp::ok()` but not thread safe).

Also, I removed the sleeps with 54a16de, the demo now starts when PSM is ready.